### PR TITLE
Move exports to the bottom of the file to fix issues w/ other libraries

### DIFF
--- a/src/es5.js
+++ b/src/es5.js
@@ -6,8 +6,6 @@ See the accompanying LICENSE file for terms.
 
 /* jslint esnext: true */
 
-export {defineProperty, objCreate};
-
 // Purposely using the same implementation as the Intl.js `Intl` polyfill.
 // Copyright 2013 Andy Earnshaw, MIT License
 
@@ -45,3 +43,5 @@ var objCreate = Object.create || function (proto, props) {
 
     return obj;
 };
+
+export {defineProperty, objCreate};

--- a/src/memoizer.js
+++ b/src/memoizer.js
@@ -8,8 +8,6 @@ See the accompanying LICENSE file for terms.
 
 import {objCreate} from './es5';
 
-export default createFormatCache;
-
 // -----------------------------------------------------------------------------
 
 function createFormatCache(FormatConstructor) {
@@ -80,3 +78,5 @@ function orderedProps(obj) {
 
     return props;
 }
+
+export default createFormatCache;


### PR DESCRIPTION
Currently, the location of the `exports` in `intl-format-cache` is causing issues with other libraries that depend on this project. See yahoo/ember-intl#249 for more details.

In short, all of the exported functions are `undefined` if left at the top of the file. Moving them to the end of the file fixes the issue.