### PR TITLE
Use `new` when calling *Format constructors

### DIFF
--- a/src/es5.js
+++ b/src/es5.js
@@ -6,42 +6,33 @@ See the accompanying LICENSE file for terms.
 
 /* jslint esnext: true */
 
-export {defineProperty, objCreate};
+export {bind};
 
-// Purposely using the same implementation as the Intl.js `Intl` polyfill.
-// Copyright 2013 Andy Earnshaw, MIT License
+// Function.prototype.bind implementation from Mozilla Developer Network:
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind#Polyfill
 
-var hop = Object.prototype.hasOwnProperty;
-
-var realDefineProp = (function () {
-    try { return !!Object.defineProperty({}, 'a', {}); }
-    catch (e) { return false; }
-})();
-
-var es3 = !realDefineProp && !Object.prototype.__defineGetter__;
-
-var defineProperty = realDefineProp ? Object.defineProperty :
-        function (obj, name, desc) {
-
-    if ('get' in desc && obj.__defineGetter__) {
-        obj.__defineGetter__(name, desc.get);
-    } else if (!hop.call(obj, name) || 'value' in desc) {
-        obj[name] = desc.value;
-    }
-};
-
-var objCreate = Object.create || function (proto, props) {
-    var obj, k;
-
-    function F() {}
-    F.prototype = proto;
-    obj = new F();
-
-    for (k in props) {
-        if (hop.call(props, k)) {
-            defineProperty(obj, k, props[k]);
-        }
+var bind = Function.prototype.bind || function (oThis) {
+    if (typeof this !== 'function') {
+      // closest thing possible to the ECMAScript 5
+      // internal IsCallable function
+      throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
     }
 
-    return obj;
+    var aArgs   = Array.prototype.slice.call(arguments, 1),
+        fToBind = this,
+        fNOP    = function() {},
+        fBound  = function() {
+          return fToBind.apply(this instanceof fNOP
+                 ? this
+                 : oThis,
+                 aArgs.concat(Array.prototype.slice.call(arguments)));
+        };
+
+    if (this.prototype) {
+      // native functions don't have a prototype
+      fNOP.prototype = this.prototype;
+    }
+    fBound.prototype = new fNOP();
+
+    return fBound;
 };

--- a/src/memoizer.js
+++ b/src/memoizer.js
@@ -22,7 +22,7 @@ function createFormatCache(FormatConstructor) {
 
         if (!format) {
             format = objCreate(FormatConstructor.prototype);
-            format = FormatConstructor.apply(format, args);
+            FormatConstructor.apply(format, args);
 
             if (cacheId) {
                 cache[cacheId] = format;

--- a/src/memoizer.js
+++ b/src/memoizer.js
@@ -6,7 +6,7 @@ See the accompanying LICENSE file for terms.
 
 /* jshint esnext: true */
 
-import {objCreate} from './es5';
+import {bind} from './es5';
 
 export default createFormatCache;
 
@@ -21,8 +21,7 @@ function createFormatCache(FormatConstructor) {
         var format  = cacheId && cache[cacheId];
 
         if (!format) {
-            format = objCreate(FormatConstructor.prototype);
-            FormatConstructor.apply(format, args);
+            format = new (bind.apply(FormatConstructor, [null].concat(args)))();
 
             if (cacheId) {
                 cache[cacheId] = format;


### PR DESCRIPTION
Fixes #9 in a way that also works with Intl MessageFormat and RelativeFormat.

The code in this PR is what an ES6 transpiler would compile the following:

```js
function construct(Constructor) {
    return (...args) => new Constructor(...args);
}
```